### PR TITLE
Convert socket related functions in network folder

### DIFF
--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -381,14 +381,13 @@ struct sockaddr_storage {
 };
 
 int socket (int, int, int);
-int socketpair (int, int, int, int [2]);
+int socketpair(int domain, int type, int protocol,
+	int fd[2] : itype(int _Checked[2]));
 
 int shutdown (int, int);
 int bind(int fd,
 	const struct sockaddr *addr : byte_count(len),
 	socklen_t len);
-int socketpair(int domain, int type, int protocol,
-	int fd[2] : itype(int _Checked[2]));
 int connect(int fd,
 	const struct sockaddr *addr : byte_count(len),
 	socklen_t len);

--- a/src/network/accept.c
+++ b/src/network/accept.c
@@ -1,7 +1,10 @@
 #include <sys/socket.h>
 #include "syscall.h"
+#pragma CHECKED_SCOPE on
 
-int accept(int fd, struct sockaddr *restrict addr, socklen_t *restrict len)
+int accept(int fd,
+	struct sockaddr *restrict addr : byte_count(*len),
+	socklen_t *restrict len : itype(restrict _Ptr<socklen_t>))
 {
 	return socketcall_cp(accept, fd, addr, len, 0, 0, 0);
 }

--- a/src/network/accept4.c
+++ b/src/network/accept4.c
@@ -3,8 +3,12 @@
 #include <errno.h>
 #include <fcntl.h>
 #include "syscall.h"
+#pragma CHECKED_SCOPE on
 
-int accept4(int fd, struct sockaddr *restrict addr, socklen_t *restrict len, int flg)
+int accept4(int fd,
+	struct sockaddr *restrict addr : byte_count(*len),
+	socklen_t *restrict len : itype(restrict _Ptr<socklen_t>),
+	int flg)
 {
 	if (!flg) return accept(fd, addr, len);
 	int ret = socketcall_cp(accept4, fd, addr, len, flg, 0, 0);

--- a/src/network/bind.c
+++ b/src/network/bind.c
@@ -1,7 +1,10 @@
 #include <sys/socket.h>
 #include "syscall.h"
+#pragma CHECKED_SCOPE on
 
-int bind(int fd, const struct sockaddr *addr, socklen_t len)
+int bind(int fd,
+	const struct sockaddr *addr : byte_count(len),
+	socklen_t len)
 {
 	return socketcall(bind, fd, addr, len, 0, 0, 0);
 }

--- a/src/network/connect.c
+++ b/src/network/connect.c
@@ -1,7 +1,10 @@
 #include <sys/socket.h>
 #include "syscall.h"
+#pragma CHECKED_SCOPE on
 
-int connect(int fd, const struct sockaddr *addr, socklen_t len)
+int connect(int fd,
+	const struct sockaddr *addr : byte_count(len),
+	socklen_t len)
 {
 	return socketcall_cp(connect, fd, addr, len, 0, 0, 0);
 }

--- a/src/network/getpeername.c
+++ b/src/network/getpeername.c
@@ -1,7 +1,10 @@
 #include <sys/socket.h>
 #include "syscall.h"
+#pragma CHECKED_SCOPE on
 
-int getpeername(int fd, struct sockaddr *restrict addr, socklen_t *restrict len)
+int getpeername(int fd,
+	struct sockaddr *restrict addr : byte_count(*len),
+	socklen_t *restrict len : itype(restrict _Ptr<socklen_t>))
 {
 	return socketcall(getpeername, fd, addr, len, 0, 0, 0);
 }

--- a/src/network/getsockname.c
+++ b/src/network/getsockname.c
@@ -1,7 +1,10 @@
 #include <sys/socket.h>
 #include "syscall.h"
+#pragma CHECKED_SCOPE on
 
-int getsockname(int fd, struct sockaddr *restrict addr, socklen_t *restrict len)
+int getsockname(int fd,
+	struct sockaddr *restrict addr : byte_count(*len),
+	socklen_t *restrict len : itype(restrict _Ptr<socklen_t>))
 {
 	return socketcall(getsockname, fd, addr, len, 0, 0, 0);
 }

--- a/src/network/getsockopt.c
+++ b/src/network/getsockopt.c
@@ -2,11 +2,14 @@
 #include <sys/time.h>
 #include <errno.h>
 #include "syscall.h"
+#pragma CHECKED_SCOPE on
 
-int getsockopt(int fd, int level, int optname, void *restrict optval, socklen_t *restrict optlen)
+int getsockopt(int fd, int level, int optname,
+	void *restrict optval : byte_count(*optlen),
+	socklen_t *restrict optlen: itype(restrict _Ptr<socklen_t>))
 {
-	long tv32[2];
-	struct timeval *tv;
+	long tv32 _Checked[2];
+	_Ptr<struct timeval> tv = 0;
 
 	int r = __socketcall(getsockopt, fd, level, optname, optval, optlen, 0);
 

--- a/src/network/recv.c
+++ b/src/network/recv.c
@@ -1,6 +1,9 @@
 #include <sys/socket.h>
+#pragma CHECKED_SCOPE on
 
-ssize_t recv(int fd, void *buf, size_t len, int flags)
+ssize_t recv(int fd,
+	void *buf : byte_count(len),
+	size_t len, int flags)
 {
 	return recvfrom(fd, buf, len, flags, 0, 0);
 }

--- a/src/network/recvfrom.c
+++ b/src/network/recvfrom.c
@@ -1,7 +1,13 @@
 #include <sys/socket.h>
 #include "syscall.h"
+#pragma CHECKED_SCOPE on
 
-ssize_t recvfrom(int fd, void *restrict buf, size_t len, int flags, struct sockaddr *restrict addr, socklen_t *restrict alen)
+ssize_t recvfrom(int fd,
+	void *restrict buf : byte_count(len),
+	size_t len,
+	int flags,
+	struct sockaddr *restrict addr : byte_count(*alen),
+	socklen_t *restrict alen : itype(restrict _Ptr<socklen_t>))
 {
 	return socketcall_cp(recvfrom, fd, buf, len, flags, addr, alen);
 }

--- a/src/network/recvmmsg.c
+++ b/src/network/recvmmsg.c
@@ -10,10 +10,13 @@
 
 hidden void __convert_scm_timestamps(struct msghdr *, socklen_t);
 
-int recvmmsg(int fd, struct mmsghdr *msgvec, unsigned int vlen, unsigned int flags, struct timespec *timeout)
+_Checked int recvmmsg(int fd,
+	struct mmsghdr *msgvec : count(vlen),
+	unsigned int vlen, unsigned int flags,
+	struct timespec *timeout : itype(_Ptr<struct timespec>))
 {
 #if LONG_MAX > INT_MAX
-	struct mmsghdr *mh = msgvec;
+	_Array_ptr<struct mmsghdr> mh : count(vlen) = msgvec;
 	unsigned int i;
 	for (i = vlen; i; i--, mh++)
 		mh->msg_hdr.__pad1 = mh->msg_hdr.__pad2 = 0;

--- a/src/network/recvmsg.c
+++ b/src/network/recvmsg.c
@@ -5,16 +5,18 @@
 #include <string.h>
 #include "syscall.h"
 
-hidden void __convert_scm_timestamps(struct msghdr *, socklen_t);
+hidden void __convert_scm_timestamps(struct msghdr *msg : itype(_Ptr<struct msghdr>),
+	socklen_t);
 
-void __convert_scm_timestamps(struct msghdr *msg, socklen_t csize)
+void __convert_scm_timestamps(struct msghdr *msg : itype(_Ptr<struct msghdr>),
+	socklen_t csize)
 {
 	if (SCM_TIMESTAMP == SCM_TIMESTAMP_OLD) return;
 	if (!msg->msg_control || !msg->msg_controllen) return;
 
-	struct cmsghdr *cmsg, *last=0;
+	_Ptr<struct cmsghdr> cmsg = 0, last=0;
 	long tmp;
-	long long tvts[2];
+	long long tvts _Checked[2];
 	int type = 0;
 
 	for (cmsg=CMSG_FIRSTHDR(msg); cmsg; cmsg=CMSG_NXTHDR(msg, cmsg)) {
@@ -47,12 +49,15 @@ void __convert_scm_timestamps(struct msghdr *msg, socklen_t csize)
 	memcpy(CMSG_DATA(cmsg), &tvts, sizeof tvts);
 }
 
-ssize_t recvmsg(int fd, struct msghdr *msg, int flags)
+_Checked ssize_t recvmsg(int fd,
+	struct msghdr *msg : itype(_Ptr<struct msghdr>),
+	int flags)
 {
 	ssize_t r;
 	socklen_t orig_controllen = msg->msg_controllen;
 #if LONG_MAX > INT_MAX
-	struct msghdr h, *orig = msg;
+	struct msghdr h = {};
+	_Ptr<struct msghdr> orig = msg;
 	if (msg) {
 		h = *msg;
 		h.__pad1 = h.__pad2 = 0;

--- a/src/network/send.c
+++ b/src/network/send.c
@@ -1,6 +1,9 @@
 #include <sys/socket.h>
+#pragma CHECKED_SCOPE on
 
-ssize_t send(int fd, const void *buf, size_t len, int flags)
+ssize_t send(int fd,
+	const void *buf : byte_count(len),
+	size_t len, int flags)
 {
 	return sendto(fd, buf, len, flags, 0, 0);
 }

--- a/src/network/sendmmsg.c
+++ b/src/network/sendmmsg.c
@@ -3,8 +3,11 @@
 #include <limits.h>
 #include <errno.h>
 #include "syscall.h"
+#pragma CHECKED_SCOPE on
 
-int sendmmsg(int fd, struct mmsghdr *msgvec, unsigned int vlen, unsigned int flags)
+int sendmmsg(int fd,
+	struct mmsghdr *msgvec : count(vlen),
+	unsigned int vlen, unsigned int flags)
 {
 #if LONG_MAX > INT_MAX
 	/* Can't use the syscall directly because the kernel has the wrong

--- a/src/network/sendmsg.c
+++ b/src/network/sendmsg.c
@@ -4,11 +4,14 @@
 #include <errno.h>
 #include "syscall.h"
 
-ssize_t sendmsg(int fd, const struct msghdr *msg, int flags)
+ssize_t sendmsg(int fd,
+	const struct msghdr *msg : itype(_Ptr<const struct msghdr>),
+	int flags)
 {
 #if LONG_MAX > INT_MAX
-	struct msghdr h;
-	struct cmsghdr chbuf[1024/sizeof(struct cmsghdr)+1], *c;
+	struct msghdr h = {};
+	struct cmsghdr chbuf _Checked[1024/sizeof(struct cmsghdr)+1];
+	_Ptr<struct cmsghdr> c = 0;
 	if (msg) {
 		h = *msg;
 		h.__pad1 = h.__pad2 = 0;

--- a/src/network/sendto.c
+++ b/src/network/sendto.c
@@ -1,7 +1,13 @@
 #include <sys/socket.h>
 #include "syscall.h"
+#pragma CHECKED_SCOPE on
 
-ssize_t sendto(int fd, const void *buf, size_t len, int flags, const struct sockaddr *addr, socklen_t alen)
+ssize_t sendto(int fd,
+	const void *buf : byte_count(len),
+	size_t len,
+	int flags,
+	const struct sockaddr *addr : byte_count(alen),
+	socklen_t alen)
 {
 	return socketcall_cp(sendto, fd, buf, len, flags, addr, alen);
 }

--- a/src/network/setsockopt.c
+++ b/src/network/setsockopt.c
@@ -2,13 +2,16 @@
 #include <sys/time.h>
 #include <errno.h>
 #include "syscall.h"
+#pragma CHECKED_SCOPE on
 
 #define IS32BIT(x) !((x)+0x80000000ULL>>32)
 #define CLAMP(x) (int)(IS32BIT(x) ? (x) : 0x7fffffffU+((0ULL+(x))>>63))
 
-int setsockopt(int fd, int level, int optname, const void *optval, socklen_t optlen)
+int setsockopt(int fd, int level, int optname,
+	const void *optval : byte_count(optlen),
+	socklen_t optlen)
 {
-	const struct timeval *tv;
+	_Ptr<const struct timeval> tv = ((void *)0);
 	time_t s;
 	suseconds_t us;
 

--- a/src/network/setsockopt.c
+++ b/src/network/setsockopt.c
@@ -11,7 +11,7 @@ int setsockopt(int fd, int level, int optname,
 	const void *optval : byte_count(optlen),
 	socklen_t optlen)
 {
-	_Ptr<const struct timeval> tv = ((void *)0);
+	_Ptr<const struct timeval> tv = 0;
 	time_t s;
 	suseconds_t us;
 

--- a/src/network/socketpair.c
+++ b/src/network/socketpair.c
@@ -2,8 +2,10 @@
 #include <fcntl.h>
 #include <errno.h>
 #include "syscall.h"
+#pragma CHECKED_SCOPE on
 
-int socketpair(int domain, int type, int protocol, int fd[2])
+int socketpair(int domain, int type, int protocol,
+	int fd[2] : itype(int _Checked[2]))
 {
 	int r = socketcall(socketpair, domain, type, protocol, fd, 0, 0);
 	if (r<0 && (errno==EINVAL || errno==EPROTONOSUPPORT)


### PR DESCRIPTION
The PR converts all structs and functions declared in `sys/socket.h`. Tested on libc-test.

All functions in thie PR are easy to convert. Basically,
- Add bounds-safe interface to the prototypes. All bounds annotations are clear to add.
- Convert local pointers to `_Ptr` or _Array_ptr`; arrays to checked arrays.