### PR TITLE
Convert functions in arpa/inet.h

### DIFF
--- a/include/arpa/inet.h
+++ b/include/arpa/inet.h
@@ -13,13 +13,19 @@ uint16_t htons(uint16_t);
 uint32_t ntohl(uint32_t);
 uint16_t ntohs(uint16_t);
 
-in_addr_t inet_addr (const char *);
-in_addr_t inet_network (const char *);
-char *inet_ntoa (struct in_addr);
-int inet_pton (int, const char *__restrict, void *__restrict);
-const char *inet_ntop (int, const void *__restrict, char *__restrict, socklen_t);
+in_addr_t inet_addr (const char *p : itype(_Nt_array_ptr<const char>));
+in_addr_t inet_network (const char *p : itype(_Nt_array_ptr<const char>));
+char *inet_ntoa (struct in_addr in) : count(15) itype(_Nt_array_ptr<char>);
+int inet_pton (int af,
+	const char *restrict s : itype(restrict _Nt_array_ptr<const char>),
+	void *restrict a0 : byte_count(af==AF_INET ? 4 : 8));
+const char *inet_ntop (int af,
+	const void *restrict a0 : byte_count(16),
+	char *restrict s : count(l),
+	socklen_t l) : itype(_Nt_array_ptr<const char>);
 
-int inet_aton (const char *, struct in_addr *);
+int inet_aton (const char *s0 : itype(_Nt_array_ptr<const char>),
+	struct in_addr *dest : itype(_Ptr<struct in_addr>));
 struct in_addr inet_makeaddr(in_addr_t, in_addr_t);
 in_addr_t inet_lnaof(struct in_addr);
 in_addr_t inet_netof(struct in_addr);

--- a/src/include/arpa/inet.h
+++ b/src/include/arpa/inet.h
@@ -3,6 +3,7 @@
 
 #include "../../../include/arpa/inet.h"
 
-hidden int __inet_aton(const char *, struct in_addr *);
+hidden int __inet_aton(const char *s0 : itype(_Nt_array_ptr<const char>),
+	struct in_addr *dest : itype(_Ptr<struct in_addr>));
 
 #endif

--- a/src/network/inet_addr.c
+++ b/src/network/inet_addr.c
@@ -1,8 +1,9 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#pragma CHECKED_SCOPE on
 
-in_addr_t inet_addr(const char *p)
+in_addr_t inet_addr(const char *p : itype(_Nt_array_ptr<const char>))
 {
 	struct in_addr a;
 	if (!__inet_aton(p, &a)) return -1;

--- a/src/network/inet_aton.c
+++ b/src/network/inet_aton.c
@@ -3,21 +3,31 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <stdlib.h>
+#pragma CHECKED_SCOPE on
 
-int __inet_aton(const char *s0, struct in_addr *dest)
+int __inet_aton(const char *s0 : itype(_Nt_array_ptr<const char>),
+	struct in_addr *dest : itype(_Ptr<struct in_addr>))
 {
-	const char *s = s0;
-	unsigned char *d = (void *)dest;
-	unsigned long a[4] = { 0 };
-	char *z;
+	_Nt_array_ptr<const char> s = s0;
+	_Array_ptr<unsigned char> d : count(4) = (_Array_ptr<unsigned char>)dest;
+	unsigned long a _Checked[4] = { 0 };
+	_Array_ptr<char> z; // Bounds are not known until the call to strtoul.
 	int i;
 
 	for (i=0; i<4; i++) {
-		a[i] = strtoul(s, &z, 0);
-		if (z==s || (*z && *z != '.') || !isdigit(*s))
+		// TODO: strtoul does not accept checked pointers yet.
+		// Since we cannot use address-of (&) operator on a checked pointer
+		// with bounds, we must widen the bounds of z using _Assume_bounds_cast
+		// after z is made point to the correct position in s through strtoul.
+		_Nt_array_ptr<char> zp = 0;
+		_Unchecked {
+			a[i] = strtoul((char *)s, (char **)&z, 0);
+			zp = _Assume_bounds_cast<_Nt_array_ptr<char>>(z, count(0));
+		}
+		if (z==s || (*zp && *zp != '.') || !isdigit(*s))
 			return 0;
-		if (!*z) break;
-		s=z+1;
+		if (!*zp) break;
+		s=(_Nt_array_ptr<const char>)zp+1;
 	}
 	if (i==4) return 0;
 	switch (i) {

--- a/src/network/inet_aton.c
+++ b/src/network/inet_aton.c
@@ -9,6 +9,7 @@ int __inet_aton(const char *s0 : itype(_Nt_array_ptr<const char>),
 	struct in_addr *dest : itype(_Ptr<struct in_addr>))
 {
 	_Nt_array_ptr<const char> s = s0;
+	// Struct in_addr has 32 bytes. Cast it to unsigned char pointer with count(4).
 	_Array_ptr<unsigned char> d : count(4) = (_Array_ptr<unsigned char>)dest;
 	unsigned long a _Checked[4] = { 0 };
 	_Array_ptr<char> z; // Bounds are not known until the call to strtoul.

--- a/src/network/inet_legacy.c
+++ b/src/network/inet_legacy.c
@@ -2,7 +2,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-in_addr_t inet_network(const char *p)
+in_addr_t inet_network(const char *p : itype(_Nt_array_ptr<const char>))
 {
 	return ntohl(inet_addr(p));
 }

--- a/src/network/inet_ntoa.c
+++ b/src/network/inet_ntoa.c
@@ -2,12 +2,12 @@
 #include <stdio.h>
 #pragma CHECKED_SCOPE on
 
-// inet_ntoa allocates and returns a null-terminated buffer of 16 bytes,
-// which converts to an nt_array_ptr with a count of 15.
+// inet_ntoa allocates and returns a null-terminated buffer of 16 bytes, which
+// corresponds to an nt_array_ptr of count(15) (16 minus 1 for the NULL byte).
 char *inet_ntoa(struct in_addr in) : count(15) itype(_Nt_array_ptr<char>)
 {
 	static char buf _Nt_checked[16];
-	// Struct in_addr has 4 bytes.
+	// Struct in_addr has 32 bytes. Cast it to unsigned char pointer with count(4).
 	_Array_ptr<unsigned char> a : count(4) = (_Array_ptr<unsigned char>)&in;
 	_Unchecked {
 		snprintf((char *)buf, sizeof buf, "%d.%d.%d.%d", a[0], a[1], a[2], a[3]);

--- a/src/network/inet_ntoa.c
+++ b/src/network/inet_ntoa.c
@@ -1,10 +1,16 @@
 #include <arpa/inet.h>
 #include <stdio.h>
+#pragma CHECKED_SCOPE on
 
-char *inet_ntoa(struct in_addr in)
+// inet_ntoa allocates and returns a null-terminated buffer of 16 bytes,
+// which converts to an nt_array_ptr with a count of 15.
+char *inet_ntoa(struct in_addr in) : count(15) itype(_Nt_array_ptr<char>)
 {
-	static char buf[16];
-	unsigned char *a = (void *)&in;
-	snprintf(buf, sizeof buf, "%d.%d.%d.%d", a[0], a[1], a[2], a[3]);
+	static char buf _Nt_checked[16];
+	// Struct in_addr has 4 bytes.
+	_Array_ptr<unsigned char> a : count(4) = (_Array_ptr<unsigned char>)&in;
+	_Unchecked {
+		snprintf((char *)buf, sizeof buf, "%d.%d.%d.%d", a[0], a[1], a[2], a[3]);
+	}
 	return buf;
 }

--- a/src/network/inet_ntop.c
+++ b/src/network/inet_ntop.c
@@ -3,46 +3,63 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#pragma CHECKED_SCOPE on
 
-const char *inet_ntop(int af, const void *restrict a0, char *restrict s, socklen_t l)
+// This function converts the network address structure a0 in the af
+// address family into a character string.  The resulting string is
+// copied to the buffer pointed to by s, which must be a non-null
+// pointer.  The caller specifies the number of bytes available in this
+// buffer in the argument l.  a0 must have at least 16 bytes.
+const char *inet_ntop(int af,
+	const void *restrict a0 : byte_count(16),
+	char *restrict s : count(l),
+	socklen_t l) : itype(_Nt_array_ptr<const char>)
 {
-	const unsigned char *a = a0;
+	_Array_ptr<const unsigned char> a : count(16) = a0;
 	int i, j, max, best;
-	char buf[100];
+	char buf _Nt_checked[100];
 
 	switch (af) {
 	case AF_INET:
-		if (snprintf(s, l, "%d.%d.%d.%d", a[0],a[1],a[2],a[3]) < l)
-			return s;
+		_Unchecked {
+			if (snprintf(s, l, "%d.%d.%d.%d", a[0],a[1],a[2],a[3]) < l)
+				return s;
+		}
 		break;
 	case AF_INET6:
-		if (memcmp(a, "\0\0\0\0\0\0\0\0\0\0\377\377", 12))
-			snprintf(buf, sizeof buf,
+		if (memcmp(a, "\0\0\0\0\0\0\0\0\0\0\377\377", 12)) _Unchecked {
+			snprintf((char *)buf, sizeof buf,
 				"%x:%x:%x:%x:%x:%x:%x:%x",
 				256*a[0]+a[1],256*a[2]+a[3],
 				256*a[4]+a[5],256*a[6]+a[7],
 				256*a[8]+a[9],256*a[10]+a[11],
 				256*a[12]+a[13],256*a[14]+a[15]);
-		else
-			snprintf(buf, sizeof buf,
+		}
+		else _Unchecked {
+			snprintf((char *)buf, sizeof buf,
 				"%x:%x:%x:%x:%x:%x:%d.%d.%d.%d",
 				256*a[0]+a[1],256*a[2]+a[3],
 				256*a[4]+a[5],256*a[6]+a[7],
 				256*a[8]+a[9],256*a[10]+a[11],
 				a[12],a[13],a[14],a[15]);
+		}
 		/* Replace longest /(^0|:)[:0]{2,}/ with "::" */
 		for (i=best=0, max=2; buf[i]; i++) {
 			if (i && buf[i] != ':') continue;
-			j = strspn(buf+i, ":0");
+			_Unchecked {
+				j = strspn((char *)buf+i, ":0");
+			}
 			if (j>max) best=i, max=j;
 		}
 		if (max>3) {
 			buf[best] = buf[best+1] = ':';
 			memmove(buf+best+2, buf+best+max, i-best-max+1);
 		}
-		if (strlen(buf) < l) {
-			strcpy(s, buf);
-			return s;
+		_Unchecked {
+			if (strlen((char *)buf) < l) {
+				strcpy((char *)s, (char *)buf);
+				return s;
+			}
 		}
 		break;
 	default:

--- a/src/network/inet_pton.c
+++ b/src/network/inet_pton.c
@@ -3,6 +3,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <string.h>
+#pragma CHECKED_SCOPE on
 
 static int hexval(unsigned c)
 {
@@ -12,21 +13,36 @@ static int hexval(unsigned c)
 	return -1;
 }
 
-int inet_pton(int af, const char *restrict s, void *restrict a0)
+// This function converts the character string s into a network
+// address structure in the af address family, then copies the network
+// address structure to a0.  The af argument must be either AF_INET or
+// AF_INET6.  a0 is written in network byte order.
+int inet_pton(int af,
+	const char *restrict s : itype(restrict _Nt_array_ptr<const char>),
+	void *restrict a0 : byte_count(af==AF_INET ? 4 : 8))
 {
-	uint16_t ip[8];
-	unsigned char *a = a0;
+	uint16_t ip _Checked[8];
+	// Length of a that will be written.
+	const int count = af==AF_INET ? 4 : 16;
+	_Array_ptr<unsigned char> a : bounds(a0, (_Array_ptr<unsigned char>)a0 + count) = a0;
 	int i, j, v, d, brk=-1, need_v4=0;
 
+	// The length of s is unknown but it is 4 at max. Currently, the compiler
+	// cannot automatically widen its bounds in the for loop. So here we assume
+	// it has length 4 using _Assume_bounds_cast, which is the best we can do.
+	_Nt_array_ptr<const char> sw : count(4) = 0;
+	_Unchecked {
+		sw = _Assume_bounds_cast<_Nt_array_ptr<const char>>(s, count(4));
+	}
 	if (af==AF_INET) {
 		for (i=0; i<4; i++) {
-			for (v=j=0; j<3 && isdigit(s[j]); j++)
-				v = 10*v + s[j]-'0';
-			if (j==0 || (j>1 && s[0]=='0') || v>255) return 0;
+			for (v=j=0; j<3 && sw[j] && isdigit(sw[j]); j++)
+				v = 10*v + sw[j]-'0';
+			if (j==0 || (j>1 && sw[0]=='0') || v>255) return 0;
 			a[i] = v;
-			if (s[j]==0 && i==3) return 1;
-			if (s[j]!='.') return 0;
-			s += j+1;
+			if (sw[j]==0 && i==3) return 1;
+			if (sw[j]!='.') return 0;
+			sw += j+1;
 		}
 		return 0;
 	} else if (af!=AF_INET6) {
@@ -34,29 +50,29 @@ int inet_pton(int af, const char *restrict s, void *restrict a0)
 		return -1;
 	}
 
-	if (*s==':' && *++s!=':') return 0;
+	if (*sw==':' && *++sw!=':') return 0;
 
 	for (i=0; ; i++) {
-		if (s[0]==':' && brk<0) {
+		if (sw[0]==':' && brk<0) {
 			brk=i;
 			ip[i&7]=0;
-			if (!*++s) break;
+			if (!*++sw) break;
 			if (i==7) return 0;
 			continue;
 		}
-		for (v=j=0; j<4 && (d=hexval(s[j]))>=0; j++)
+		for (v=j=0; j<4 && (d=hexval(sw[j]))>=0; j++)
 			v=16*v+d;
 		if (j==0) return 0;
 		ip[i&7] = v;
-		if (!s[j] && (brk>=0 || i==7)) break;
+		if (!sw[j] && (brk>=0 || i==7)) break;
 		if (i==7) return 0;
-		if (s[j]!=':') {
-			if (s[j]!='.' || (i<6 && brk<0)) return 0;
+		if (sw[j]!=':') {
+			if (sw[j]!='.' || (i<6 && brk<0)) return 0;
 			need_v4=1;
 			i++;
 			break;
 		}
-		s += j+1;
+		sw += j+1;
 	}
 	if (brk>=0) {
 		memmove(ip+brk+7-i, ip+brk, 2*(i+1-brk));
@@ -66,6 +82,6 @@ int inet_pton(int af, const char *restrict s, void *restrict a0)
 		*a++ = ip[j]>>8;
 		*a++ = ip[j];
 	}
-	if (need_v4 && inet_pton(AF_INET, (void *)s, a-4) <= 0) return 0;
+	if (need_v4 && inet_pton(AF_INET, sw, a-4) <= 0) return 0;
 	return 1;
 }


### PR DESCRIPTION
This PR converts all the functions declared in the header `arpa/inet.h` (6 need to be converted in total). They are implemented in `network/inet_*.c`

I try to put all converted code under checked scopes. Code that is impossible to live in a checked scope is explicitly enclosed with an `_Unchecked` block. The reason is one of the following:
- A variadic function is called, e.g., `snprintf`.
- A function that does not have a bounds safe interface yet is called, e.g., `strtoul`. In such cases, we need a cast from checked pointers to unchecked pointers to pass parameters. All such usages are marked with a TODO, since the unchecked blocks can be removed once the functions are annotated with bounds-safe interface.
- Null-terminated strings with unknown bounds must be widened due to the limitation of the current compiler analysis. In such cases, a new nt_array_ptr with widened bounds is declared. All such usages are commented with a brief explanation.