### PR TITLE
Convert netdb functions and lookup functions

### DIFF
--- a/include/netdb.h
+++ b/include/netdb.h
@@ -100,9 +100,13 @@ struct netent *getnetbyname (const char *);
 
 void setservent (int);
 void endservent (void);
-struct servent *getservent (void);
-struct servent *getservbyname (const char *, const char *);
-struct servent *getservbyport (int, const char *);
+struct servent *getservent (void) : itype(_Ptr<struct servent>);
+struct servent *getservbyname (const char *name : itype(_Nt_array_ptr<const char>),
+	const char *prots : itype(_Nt_array_ptr<const char>))
+	: itype(_Ptr<struct servent>);
+struct servent *getservbyport (int port,
+	const char *prots : itype(_Nt_array_ptr<const char>))
+	: itype(_Ptr<struct servent>);
 
 void setprotoent (int);
 void endprotoent (void);
@@ -130,12 +134,40 @@ int *__h_errno_location(void);
 #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
 void herror(const char *);
 const char *hstrerror(int);
-int gethostbyname_r(const char *, struct hostent *, char *, size_t, struct hostent **, int *);
-int gethostbyname2_r(const char *, int, struct hostent *, char *, size_t, struct hostent **, int *);
-struct hostent *gethostbyname2(const char *, int);
-int gethostbyaddr_r(const void *, socklen_t, int, struct hostent *, char *, size_t, struct hostent **, int *);
-int getservbyport_r(int, const char *, struct servent *, char *, size_t, struct servent **);
-int getservbyname_r(const char *, const char *, struct servent *, char *, size_t, struct servent **);
+int gethostbyname_r(const char *name : itype(_Nt_array_ptr<const char>),
+	struct hostent *h : itype(_Ptr<struct hostent>),
+	char *buf : count(buflen),
+	size_t buflen,
+	struct hostent **res : itype(_Ptr<_Ptr<struct hostent>>),
+	int *err : itype(_Ptr<int>));
+int gethostbyname2_r(const char *name : itype(_Nt_array_ptr<const char>),
+	int af,
+	struct hostent *h : itype(_Ptr<struct hostent>),
+	char *buf : count(buflen),
+	size_t buflen,
+	struct hostent **res : itype(_Ptr<_Ptr<struct hostent>>),
+	int *err : itype(_Ptr<int>));
+struct hostent *gethostbyname2(const char *name : itype(_Nt_array_ptr<const char>),
+	int af) : itype(_Ptr<struct hostent>);
+int gethostbyaddr_r(const void *a : byte_count(l),
+	socklen_t l, int af,
+	struct hostent *h : itype(_Ptr<struct hostent>),
+	char *buf : count(buflen),
+	size_t buflen,
+	struct hostent **res : itype(_Ptr<_Ptr<struct hostent>>),
+	int *err : itype(_Ptr<int>));
+int getservbyport_r(int port,
+	const char *prots : itype(_Nt_array_ptr<const char>),
+	struct servent *se : itype(_Ptr<struct servent>),
+	char *buf : count(buflen),
+	size_t buflen,
+	struct servent **res : itype(_Ptr<_Ptr<struct servent>>));
+int getservbyname_r(const char *name : itype(_Nt_array_ptr<const char>),
+	const char *prots : itype(_Nt_array_ptr<const char>),
+	struct servent *se : itype(_Ptr<struct servent>),
+	char *buf : count(buflen),
+	size_t buflen,
+	struct servent **res : itype(_Ptr<_Ptr<struct servent>>));
 #define EAI_NODATA     -5
 #define EAI_ADDRFAMILY -9
 #define EAI_INPROGRESS -100

--- a/src/network/gethostbyaddr_r.c
+++ b/src/network/gethostbyaddr_r.c
@@ -7,9 +7,14 @@
 #include <errno.h>
 #include <inttypes.h>
 
-int gethostbyaddr_r(const void *a, socklen_t l, int af,
-	struct hostent *h, char *buf, size_t buflen,
-	struct hostent **res, int *err)
+int gethostbyaddr_r(const void *a : byte_count(l),
+	socklen_t l,
+	int af,
+	struct hostent *h : itype(_Ptr<struct hostent>),
+	char *buf : count(buflen),
+	size_t buflen,
+	struct hostent **res : itype(_Ptr<_Ptr<struct hostent>>),
+	int *err : itype(_Ptr<int>))
 {
 	union {
 		struct sockaddr_in sin;

--- a/src/network/gethostbyname2.c
+++ b/src/network/gethostbyname2.c
@@ -5,11 +5,12 @@
 #include <errno.h>
 #include <stdlib.h>
 
-struct hostent *gethostbyname2(const char *name, int af)
+struct hostent *gethostbyname2(const char *name : itype(_Nt_array_ptr<const char>),
+	int af) : itype(_Ptr<struct hostent>)
 {
 	static struct hostent *h;
 	size_t size = 63;
-	struct hostent *res;
+	_Ptr<struct hostent> res = 0;
 	int err;
 	do {
 		free(h);

--- a/src/network/gethostbyname2_r.c
+++ b/src/network/gethostbyname2_r.c
@@ -8,12 +8,16 @@
 #include <stdint.h>
 #include "lookup.h"
 
-int gethostbyname2_r(const char *name, int af,
-	struct hostent *h, char *buf, size_t buflen,
-	struct hostent **res, int *err)
+int gethostbyname2_r(const char *name : itype(_Nt_array_ptr<const char>),
+	int af,
+	struct hostent *h : itype(_Ptr<struct hostent>),
+	char *buf : count(buflen),
+	size_t buflen,
+	struct hostent **res : itype(_Ptr<_Ptr<struct hostent>>),
+	int *err : itype(_Ptr<int>))
 {
-	struct address addrs[MAXADDRS];
-	char canon[256];
+	struct address addrs _Checked[MAXADDRS];
+	char canon _Nt_checked[256];
 	int i, cnt;
 	size_t align, need;
 
@@ -45,7 +49,7 @@ int gethostbyname2_r(const char *name, int af,
 	need = 4*sizeof(char *);
 	need += (cnt + 1) * (sizeof(char *) + h->h_length);
 	need += strlen(name)+1;
-	need += strlen(canon)+1;
+	need += strlen((const char *)canon)+1;
 	need += align;
 
 	if (need > buflen) return ERANGE;
@@ -64,7 +68,7 @@ int gethostbyname2_r(const char *name, int af,
 	h->h_addr_list[i] = 0;
 
 	h->h_name = h->h_aliases[0] = buf;
-	strcpy(h->h_name, canon);
+	strcpy(h->h_name, (const char *)canon);
 	buf += strlen(h->h_name)+1;
 
 	if (strcmp(h->h_name, name)) {

--- a/src/network/gethostbyname2_r.c
+++ b/src/network/gethostbyname2_r.c
@@ -49,6 +49,7 @@ int gethostbyname2_r(const char *name : itype(_Nt_array_ptr<const char>),
 	need = 4*sizeof(char *);
 	need += (cnt + 1) * (sizeof(char *) + h->h_length);
 	need += strlen(name)+1;
+	// TODO: strlen does not accept checked pointers yet.
 	need += strlen((const char *)canon)+1;
 	need += align;
 
@@ -68,6 +69,7 @@ int gethostbyname2_r(const char *name : itype(_Nt_array_ptr<const char>),
 	h->h_addr_list[i] = 0;
 
 	h->h_name = h->h_aliases[0] = buf;
+	// TODO: strlen does not accept checked pointers yet.
 	strcpy(h->h_name, (const char *)canon);
 	buf += strlen(h->h_name)+1;
 

--- a/src/network/gethostbyname_r.c
+++ b/src/network/gethostbyname_r.c
@@ -3,9 +3,12 @@
 #include <sys/socket.h>
 #include <netdb.h>
 
-int gethostbyname_r(const char *name,
-	struct hostent *h, char *buf, size_t buflen,
-	struct hostent **res, int *err)
+int gethostbyname_r(const char *name : itype(_Nt_array_ptr<const char>),
+	struct hostent *h : itype(_Ptr<struct hostent>),
+	char *buf : count(buflen),
+	size_t buflen,
+	struct hostent **res : itype(_Ptr<_Ptr<struct hostent>>),
+	int *err : itype(_Ptr<int>))
 {
 	return gethostbyname2_r(name, AF_INET, h, buf, buflen, res, err);
 }

--- a/src/network/getservbyname.c
+++ b/src/network/getservbyname.c
@@ -1,12 +1,14 @@
 #define _GNU_SOURCE
 #include <netdb.h>
 
-struct servent *getservbyname(const char *name, const char *prots)
+struct servent *getservbyname(const char *name : itype(_Nt_array_ptr<const char>),
+	const char *prots : itype(_Nt_array_ptr<const char>))
+	: itype(_Ptr<struct servent>)
 {
 	static struct servent se;
-	static char *buf[2];
-	struct servent *res;
-	if (getservbyname_r(name, prots, &se, (void *)buf, sizeof buf, &res))
+	static _Array_ptr<char> buf _Checked[2];
+	_Ptr<struct servent> res = 0;
+	if (getservbyname_r(name, prots, &se, (_Array_ptr<char>)buf, sizeof buf, &res))
 		return 0;
 	return &se;
 }

--- a/src/network/getservbyname_r.c
+++ b/src/network/getservbyname_r.c
@@ -10,8 +10,12 @@
 
 #define ALIGN (sizeof(struct { char a; char *b; }) - sizeof(char *))
 
-int getservbyname_r(const char *name, const char *prots,
-	struct servent *se, char *buf, size_t buflen, struct servent **res)
+int getservbyname_r(const char *name : itype(_Nt_array_ptr<const char>),
+	const char *prots : itype(_Nt_array_ptr<const char>),
+	struct servent *se : itype(_Ptr<struct servent>),
+	char *buf : count(buflen),
+	size_t buflen,
+	struct servent **res : itype(_Ptr<_Ptr<struct servent>>))
 {
 	struct service servs[MAXSERVS];
 	int cnt, proto, align;

--- a/src/network/getservbyport.c
+++ b/src/network/getservbyport.c
@@ -1,11 +1,13 @@
 #define _GNU_SOURCE
 #include <netdb.h>
 
-struct servent *getservbyport(int port, const char *prots)
+struct servent *getservbyport(int port,
+	const char *prots : itype(_Nt_array_ptr<const char>))
+	: itype(_Ptr<struct servent>)
 {
 	static struct servent se;
-	static long buf[32/sizeof(long)];
-	struct servent *res;
+	static long buf _Checked[32/sizeof(long)];
+	_Ptr<struct servent> res = 0;
 	if (getservbyport_r(port, prots, &se, (void *)buf, sizeof buf, &res))
 		return 0;
 	return &se;

--- a/src/network/getservbyport_r.c
+++ b/src/network/getservbyport_r.c
@@ -7,8 +7,12 @@
 #include <string.h>
 #include <stdlib.h>
 
-int getservbyport_r(int port, const char *prots,
-	struct servent *se, char *buf, size_t buflen, struct servent **res)
+int getservbyport_r(int port,
+	const char *prots : itype(_Nt_array_ptr<const char>),
+	struct servent *se : itype(_Ptr<struct servent>),
+	char *buf : count(buflen),
+	size_t buflen,
+	struct servent **res : itype(_Ptr<_Ptr<struct servent>>))
 {
 	int i;
 	struct sockaddr_in sin = {

--- a/src/network/lookup.h
+++ b/src/network/lookup.h
@@ -43,8 +43,15 @@ struct resolvconf {
 #define MAXADDRS 48
 #define MAXSERVS 2
 
-hidden int __lookup_serv(struct service buf[static MAXSERVS], const char *name, int proto, int socktype, int flags);
-hidden int __lookup_name(struct address buf[static MAXADDRS], char canon[static 256], const char *name, int family, int flags);
+hidden int __lookup_serv(
+	struct service buf[static MAXSERVS] : itype(struct service _Checked[static MAXSERVS]),
+	const char *name : itype(_Nt_array_ptr<const char>),
+	int proto, int socktype, int flags);
+hidden int __lookup_name(
+	struct address buf[static MAXADDRS] : itype(struct address _Checked[static MAXADDRS]),
+	char canon[static 256] : itype(char _Nt_checked[static 256]),
+	const char *name : itype(_Nt_array_ptr<const char>),
+	int family, int flags);
 hidden int __lookup_ipliteral(struct address buf[static 1], const char *name, int family);
 
 hidden int __get_resolv_conf(struct resolvconf *, char *, size_t);


### PR DESCRIPTION
- Converted 9 functions in `netdb.h`.
- Converted 2 internal hidden functions in `network/lookup.h` which are used by the netdb functions.
- Passed libc-test.

Adding bounds safe interfaces and converting types of local pointers account for nearly all changes.