### PR TITLE
Remove useless ifdef __clang__ and add temp var for some functions

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -91,10 +91,10 @@ int strerror_r (int, char *, size_t);
 char *stpcpy(char *__restrict, const char *__restrict);
 // Copies at most n characters from the string pointed to by src, including the terminating null byte ('\0'),
 // to the array pointed to by dest.
-char *stpncpy(char *restrict d : itype(restrict _Nt_array_ptr<char>) count(n),
+char *stpncpy(char *restrict d : itype(restrict _Array_ptr<char>) count(n),
               const char *restrict s,
               size_t n)
-  :itype(_Nt_array_ptr<char>) count(n);
+  :itype(_Array_ptr<char>) count(n);
 // Returns the number of bytes in the string pointed to by s, excluding the terminating null byte ('\0').
 size_t strnlen (const char * : itype(_Array_ptr<const char>) count(n), size_t n);
 char *strdup (const char *);

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -50,11 +50,10 @@ extern "C" {
 wchar_t *wcscpy (wchar_t *__restrict, const wchar_t *__restrict);
 // Copies the first n characters of source to destination. If the end of the source C wide string is found before n characters have been copied,
 // destination is padded with additional null wide characters until a total of n characters have been written to it.
-wchar_t *wcsncpy(wchar_t *restrict d : itype(__restrict _Array_ptr<wchar_t>) count(n),
+wchar_t *wcsncpy(wchar_t *restrict d : itype(__restrict _Nt_array_ptr<wchar_t>) count(n),
                  const wchar_t *restrict s,
                  size_t n)
   : itype(_Nt_array_ptr<wchar_t>) count(n);
-
 wchar_t *wcscat (wchar_t *__restrict, const wchar_t *__restrict);
 wchar_t *wcsncat (wchar_t *__restrict, const wchar_t *__restrict, size_t);
 

--- a/src/include/string.h
+++ b/src/include/string.h
@@ -5,10 +5,10 @@
 
 hidden void *__memrchr(const void *, int, size_t);
 hidden char *__stpcpy(char *, const char *);
-hidden char *__stpncpy(char *restrict d : itype(restrict _Nt_array_ptr<char>) count(n),
-                       const char *restrict s : itype(restrict _Nt_array_ptr<const char>) count(n),
+hidden char *__stpncpy(char *restrict d : itype(restrict _Array_ptr<char>) count(n),
+                       const char *restrict s,
                        size_t n)
-  :itype(_Nt_array_ptr<char>) count(n);
+  :itype(_Array_ptr<char>) count(n);
 hidden char *__strchrnul(const char *, int);
 
 #endif

--- a/src/string/memccpy.c
+++ b/src/string/memccpy.c
@@ -18,23 +18,19 @@ _Checked
         _Array_ptr<const unsigned char> s : count(n) = (_Array_ptr<const unsigned char>)src;
 
 	c = (unsigned char)c;
-// This part is GCC Specific code and uses unchecked pointer,
-// Clang compiler should not compile this part.
 #ifdef __GNUC__
-#ifndef __clang__
 	typedef size_t __attribute__((__may_alias__)) word;
-	word *wd;
-	const word *ws;
+	_Array_ptr<word> wd : count(n) = 0;
+	_Array_ptr<const word> ws : count(n) = 0;
 	if (((uintptr_t)s & ALIGN) == ((uintptr_t)d & ALIGN)) {
 		for (; ((uintptr_t)s & ALIGN) && n && (*d=*s)!=c; n--, s++, d++);
 		if ((uintptr_t)s & ALIGN) goto tail;
 		size_t k = ONES * c;
-		wd=(void *)d; ws=(const void *)s;
+		wd= (_Array_ptr<void>) d; ws= (_Array_ptr<const void>) s;
 		for (; n>=sizeof(size_t) && !HASZERO(*ws^k);
 		       n-=sizeof(size_t), ws++, wd++) *wd = *ws;
-		d=(void *)wd; s=(const void *)ws;
+		d= (_Array_ptr<void>) wd; s= (_Array_ptr<const void>) ws;
 	}
-#endif
 #endif
 	for (; n && (*d=*s)!=c; n--, s++, d++);
 tail:

--- a/src/string/memchr.c
+++ b/src/string/memchr.c
@@ -15,14 +15,14 @@ void *memchr (const void *src : itype(_Array_ptr<const void>) byte_count(n),
 
 _Checked
 {
-	_Array_ptr<const unsigned char> s : count(n) = (_Array_ptr<const unsigned char>) src;
+	_Array_ptr<const unsigned char> s : count(n / sizeof(const unsigned char)) = (_Array_ptr<const unsigned char>) src;
 	c = (unsigned char)c;
 
 #ifdef __GNUC__
 	for (; ((uintptr_t)s & ALIGN) && n && *s != c; s++, n--);
 	if (n && *s != c) {
 		typedef size_t __attribute__((__may_alias__)) word;
-		_Array_ptr<const word> w : count(n) = 0;
+		_Array_ptr<const word> w : count(n / sizeof(const word)) = 0;
 		size_t k = ONES * c;
 		for (w = (_Array_ptr<const void>)s; n>=SS && !HASZERO(*w^k); w++, n-=SS);
 		s = (_Array_ptr<const void>)w;

--- a/src/string/memcpy.c
+++ b/src/string/memcpy.c
@@ -11,10 +11,7 @@ _Checked
         _Array_ptr<unsigned char> d : count(n) = dest;
         _Array_ptr<const unsigned char> s : count(n) = src;
 
-// This part is GCC Specific code and uses unchecked pointer,
-// Clang compiler should not compile this part.
 #ifdef __GNUC__
-#ifndef __clang__
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 #define LS >>
 #define RS <<
@@ -122,7 +119,6 @@ _Checked
 		*d = *s;
 	}
 	return dest;
-#endif
 #endif
 
 	for (; n; n--) *d++ = *s++;

--- a/src/string/memmove.c
+++ b/src/string/memmove.c
@@ -18,10 +18,7 @@ _Checked{
 	if ((uintptr_t)s-(uintptr_t)d-n <= -2*n) return memcpy(d, s, n);
 
 	if (d<s) {
-// This part is GCC Specific code and uses unchecked pointer,
-// Clang compiler should not compile this part.
 #ifdef __GNUC__
-#ifndef __clang__
 		if ((uintptr_t)s % WS == (uintptr_t)d % WS) {
 			while ((uintptr_t)d % WS) {
 				if (!n--) return dest;
@@ -30,13 +27,9 @@ _Checked{
 			for (; n>=WS; n-=WS, d+=WS, s+=WS) *(WT *)d = *(WT *)s;
 		}
 #endif
-#endif
 		for (; n; n--) *d++ = *s++;
 	} else {
-// This part is GCC Specific code and uses unchecked pointer,
-// Clang compiler should not compile this part.
 #ifdef __GNUC__
-#ifndef __clang__
 		if ((uintptr_t)s % WS == (uintptr_t)d % WS) {
 			while ((uintptr_t)(d+n) % WS) {
 				if (!n--) return dest;
@@ -44,7 +37,6 @@ _Checked{
 			}
 			while (n>=WS) n-=WS, *(WT *)(d+n) = *(WT *)(s+n);
 		}
-#endif
 #endif
 		while (n) n--, d[n] = s[n];
 	}

--- a/src/string/memset.c
+++ b/src/string/memset.c
@@ -37,10 +37,7 @@ _Checked
 	n -= k;
 	n &= -4;
 
-// This part is GCC Specific code and uses unchecked pointer,
-// Clang compiler should not compile this part.
 #ifdef __GNUC__
-#ifndef __clang__
 	typedef uint32_t __attribute__((__may_alias__)) u32;
 	typedef uint64_t __attribute__((__may_alias__)) u64;
 
@@ -88,7 +85,6 @@ _Checked
 		*(u64 *)(s+16) = c64;
 		*(u64 *)(s+24) = c64;
 	}
-#endif
 #else
 	/* Pure C fallback with no aliasing violations. */
 	for (; n; n--, s++) *s = c;

--- a/src/string/stpncpy.c
+++ b/src/string/stpncpy.c
@@ -12,7 +12,8 @@ char *__stpncpy(char *restrict d : itype(restrict _Array_ptr<char>) count(n),
                 size_t n)
   : itype(_Array_ptr<char>) count(n)
 {
-// n and d are used in the declared bounds of d. But both are modified in the loop and hence the declared bounds of d no
+// n and d are used in the declared bounds of d. But both are modified in the
+// loop and hence the declared bounds of d no
 // longer remain valid. So we need to use a temp variable in this function.
 	size_t temp_n = n;
 	restrict _Array_ptr<char> temp_d : count(n) = d;

--- a/src/string/stpncpy.c
+++ b/src/string/stpncpy.c
@@ -12,23 +12,27 @@ char *__stpncpy(char *restrict d : itype(restrict _Array_ptr<char>) count(n),
                 size_t n)
   : itype(_Array_ptr<char>) count(n)
 {
+// n and d are used in the declared bounds of d. But both are modified in the loop and hence the declared bounds of d no
+// longer remain valid. So we need to use a temp variable in this function.
+	size_t temp_n = n;
+	restrict _Array_ptr<char> temp_d : count(n) = d;
 #ifdef __GNUC__
 	typedef size_t __attribute__((__may_alias__)) word;
 	_Array_ptr<word> wd : count(n) = 0;
 	const word *ws;
 	if (((uintptr_t)s & ALIGN) == ((uintptr_t)d & ALIGN)) {
-		for (; ((uintptr_t)s & ALIGN) && n && (*d=*s); n--, s++, d++);
-		if (!n || !*s) goto tail;
-		wd=(_Array_ptr<word>)d; ws=(const void *)s;
-		for (; n>=sizeof(size_t) && !HASZERO(*ws);
-		       n-=sizeof(size_t), ws++, wd++) *wd = *ws;
-		d=(restrict _Array_ptr<void>)wd; s=(const void *)ws;
+		for (; ((uintptr_t)s & ALIGN) && temp_n && (*temp_d=*s); temp_n--, s++, temp_d++);
+		if (!temp_n || !*s) goto tail;
+		wd=(_Array_ptr<word>)temp_d; ws=(const void *)s;
+		for (; temp_n>=sizeof(size_t) && !HASZERO(*ws);
+		       temp_n-=sizeof(size_t), ws++, wd++) *wd = *ws;
+		temp_d=(restrict _Array_ptr<void>)wd; s=(const void *)ws;
 	}
 #endif
-	for (; n && (*d=*s); n--, s++, d++);
+	for (; temp_n && (*temp_d=*s); temp_n--, s++, temp_d++);
 tail:
-	memset(d, 0, n);
-	return (_Array_ptr<char>)d;
+	memset(temp_d, 0, temp_n);
+	return (_Array_ptr<char>)temp_d;
 }
 
 weak_alias(__stpncpy, stpncpy);

--- a/src/string/stpncpy.c
+++ b/src/string/stpncpy.c
@@ -12,9 +12,9 @@ char *__stpncpy(char *restrict d : itype(restrict _Array_ptr<char>) count(n),
                 size_t n)
   : itype(_Array_ptr<char>) count(n)
 {
-// n and d are used in the declared bounds of d. But both are modified in the
-// loop and hence the declared bounds of d no
-// longer remain valid. So we need to use a temp variable in this function.
+	// n and d are used in the declared bounds of d. But both are modified in the
+	// loop and hence the declared bounds of d no
+	// longer remain valid. So we need to use a temp variable in this function.
 	size_t temp_n = n;
 	restrict _Array_ptr<char> temp_d : count(n) = d;
 #ifdef __GNUC__

--- a/src/string/strnlen.c
+++ b/src/string/strnlen.c
@@ -2,6 +2,6 @@
 
 size_t strnlen(const char *s : itype(_Array_ptr<const char>) count(n), size_t n)
 _Checked{
-	_Array_ptr<const char> p : count(n) = memchr(s, 0, n);
+	_Array_ptr<const char> p : count(n / sizeof(const char)) = memchr(s, 0, n);
 	return p ? p-s : n;
 }

--- a/src/string/swab.c
+++ b/src/string/swab.c
@@ -7,9 +7,9 @@ _Checked{
 	_Array_ptr<const char> src : count(n / sizeof(char)) = (_Array_ptr<const char>) _src;
 	_Array_ptr<char> dest: count(n /sizeof(char)) = (_Array_ptr<char>) _dest;
 
-// n is used in the declared bounds of src and dest. But n is modified in the
-// loop and hence the declared bounds of src and dest no
-// longer remain valid. So we need to use a temp variable in this function.
+	// n is used in the declared bounds of src and dest. But n is modified in the
+	// loop and hence the declared bounds of src and dest no
+	// longer remain valid. So we need to use a temp variable in this function.
 	ssize_t temp_n = n;
 	for (; temp_n>1; temp_n-=2) {
 		dest[0] = src[1];

--- a/src/string/swab.c
+++ b/src/string/swab.c
@@ -6,7 +6,11 @@ void swab(const void *restrict _src : itype(restrict _Array_ptr<const void>) byt
 _Checked{
 	_Array_ptr<const char> src : count(n / sizeof(char)) = (_Array_ptr<const char>) _src;
 	_Array_ptr<char> dest: count(n /sizeof(char)) = (_Array_ptr<char>) _dest;
-	for (; n>1; n-=2) {
+
+// n is used in the declared bounds of src and dest. But n is modified in the loop and hence the declared bounds of src and dest no
+// longer remain valid. So we need to use a temp variable in this function.
+	ssize_t temp_n = n;
+	for (; temp_n>1; temp_n-=2) {
 		dest[0] = src[1];
 		dest[1] = src[0];
 		dest += 2;

--- a/src/string/swab.c
+++ b/src/string/swab.c
@@ -7,7 +7,8 @@ _Checked{
 	_Array_ptr<const char> src : count(n / sizeof(char)) = (_Array_ptr<const char>) _src;
 	_Array_ptr<char> dest: count(n /sizeof(char)) = (_Array_ptr<char>) _dest;
 
-// n is used in the declared bounds of src and dest. But n is modified in the loop and hence the declared bounds of src and dest no
+// n is used in the declared bounds of src and dest. But n is modified in the
+// loop and hence the declared bounds of src and dest no
 // longer remain valid. So we need to use a temp variable in this function.
 	ssize_t temp_n = n;
 	for (; temp_n>1; temp_n-=2) {

--- a/src/string/wcsncpy.c
+++ b/src/string/wcsncpy.c
@@ -4,7 +4,8 @@ wchar_t *wcsncpy(wchar_t *restrict d : itype(restrict _Nt_array_ptr<wchar_t>) co
   : itype(_Nt_array_ptr<wchar_t>) count(n)
 {
 
-// n and d are used in the declared bounds of d. But both of them are modified in the loop and hence the declared bounds of d no
+// n and d are used in the declared bounds of d. But both of them are modified
+// in the loop and hence the declared bounds of d no
 // longer remain valid. So we need to use a temp variable in this function.
 	size_t temp_n = n;
 	_Nt_array_ptr<wchar_t> a : count(n) = (_Nt_array_ptr<wchar_t>)d;

--- a/src/string/wcsncpy.c
+++ b/src/string/wcsncpy.c
@@ -4,9 +4,9 @@ wchar_t *wcsncpy(wchar_t *restrict d : itype(restrict _Nt_array_ptr<wchar_t>) co
   : itype(_Nt_array_ptr<wchar_t>) count(n)
 {
 
-// n and d are used in the declared bounds of d. But both of them are modified
-// in the loop and hence the declared bounds of d no
-// longer remain valid. So we need to use a temp variable in this function.
+	// n and d are used in the declared bounds of d. But both of them are modified
+	// in the loop and hence the declared bounds of d no
+	// longer remain valid. So we need to use a temp variable in this function.
 	size_t temp_n = n;
 	_Nt_array_ptr<wchar_t> a : count(n) = (_Nt_array_ptr<wchar_t>)d;
 	_Nt_array_ptr<wchar_t> temp_d : count(n) = (_Nt_array_ptr<wchar_t>)d;

--- a/src/string/wcsncpy.c
+++ b/src/string/wcsncpy.c
@@ -3,8 +3,13 @@
 wchar_t *wcsncpy(wchar_t *restrict d : itype(restrict _Nt_array_ptr<wchar_t>) count(n), const wchar_t *restrict s, size_t n)
   : itype(_Nt_array_ptr<wchar_t>) count(n)
 {
+
+// n and d are used in the declared bounds of d. But both of them are modified in the loop and hence the declared bounds of d no
+// longer remain valid. So we need to use a temp variable in this function.
+	size_t temp_n = n;
 	_Nt_array_ptr<wchar_t> a : count(n) = (_Nt_array_ptr<wchar_t>)d;
-	while (n && *s) n--, *d++ = *s++;
-	wmemset(d, 0, n);
+	_Nt_array_ptr<wchar_t> temp_d : count(n) = (_Nt_array_ptr<wchar_t>)d;
+	while (temp_n && *s) temp_n--, *temp_d++ = *s++;
+	wmemset(temp_d, 0, temp_n);
 	return a;
 }

--- a/src/string/wcsnlen.c
+++ b/src/string/wcsnlen.c
@@ -3,7 +3,8 @@
 size_t wcsnlen(const wchar_t *s : itype(_Nt_array_ptr<const wchar_t>), size_t n)
 _Checked{
 
-// n is used in the declared bounds of d. But n is modified in the loop and hence the declared bounds of d no
+// n is used in the declared bounds of d. But n is modified in the loop and
+// hence the declared bounds of d no
 // longer remain valid. So we need to use a temp variable in this function.
 	size_t temp_n = n;
 	_Nt_array_ptr<const wchar_t> z : count(n) = wmemchr(s, 0, n);

--- a/src/string/wcsnlen.c
+++ b/src/string/wcsnlen.c
@@ -3,9 +3,9 @@
 size_t wcsnlen(const wchar_t *s : itype(_Nt_array_ptr<const wchar_t>), size_t n)
 _Checked{
 
-// n is used in the declared bounds of d. But n is modified in the loop and
-// hence the declared bounds of d no
-// longer remain valid. So we need to use a temp variable in this function.
+	// n is used in the declared bounds of d. But n is modified in the loop and
+	// hence the declared bounds of d no
+	// longer remain valid. So we need to use a temp variable in this function.
 	size_t temp_n = n;
 	_Nt_array_ptr<const wchar_t> z : count(n) = wmemchr(s, 0, n);
 	if (z) temp_n = z-s;

--- a/src/string/wcsnlen.c
+++ b/src/string/wcsnlen.c
@@ -2,7 +2,11 @@
 
 size_t wcsnlen(const wchar_t *s : itype(_Nt_array_ptr<const wchar_t>), size_t n)
 _Checked{
+
+// n is used in the declared bounds of d. But n is modified in the loop and hence the declared bounds of d no
+// longer remain valid. So we need to use a temp variable in this function.
+	size_t temp_n = n;
 	_Nt_array_ptr<const wchar_t> z : count(n) = wmemchr(s, 0, n);
-	if (z) n = z-s;
-	return n;
+	if (z) temp_n = z-s;
+	return temp_n;
 }


### PR DESCRIPTION
In this PR the useless #ifdef __clang has been removed from some functions and also for the Vars that are used in bounds declaration and are modified in the function body new temp Vars are added. 