### PR TITLE
Fix compiler assertion failure in network and compile error in string

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -96,7 +96,7 @@ char *stpncpy(char *restrict d : itype(restrict _Array_ptr<char>) count(n),
               size_t n)
   :itype(_Array_ptr<char>) count(n);
 // Returns the number of bytes in the string pointed to by s, excluding the terminating null byte ('\0').
-size_t strnlen (const char * : itype(_Nt_array_ptr<const char>), size_t n);
+size_t strnlen (const char * : itype(_Nt_array_ptr<const char>) count(n), size_t n);
 char *strdup (const char *);
 char *strndup (const char *, size_t);
 char *strsignal(int);

--- a/src/network/ns_parse.c
+++ b/src/network/ns_parse.c
@@ -35,16 +35,22 @@ _Checked unsigned long ns_get32(const unsigned char *cp : count(4))
 
 _Checked void ns_put16(unsigned s, unsigned char *cp : count(2))
 {
-	*cp++ = s>>8;
-	*cp++ = s;
+	*cp = s>>8;
+	cp++;
+	*cp = s;
+	cp++;
 }
 
 _Checked void ns_put32(unsigned long l, unsigned char *cp : count(4))
 {
-	*cp++ = l>>24;
-	*cp++ = l>>16;
-	*cp++ = l>>8;
-	*cp++ = l;
+	*cp = l>>24;
+	cp++;
+	*cp = l>>16;
+	cp++;
+	*cp = l>>8;
+	cp++;
+	*cp = l;
+	cp++;
 }
 
 _Checked int ns_initparse(const unsigned char *msg : count(msglen),

--- a/src/string/strnlen.c
+++ b/src/string/strnlen.c
@@ -1,6 +1,6 @@
 #include <string.h>
 
-size_t strnlen(const char *s : itype(_Array_ptr<const char>) count(n), size_t n)
+size_t strnlen(const char *s : itype(_Nt_array_ptr<const char>) count(n), size_t n)
 _Checked{
 	_Array_ptr<const char> p : count(n / sizeof(const char)) = memchr(s, 0, n);
 	return p ? p-s : n;


### PR DESCRIPTION
This PR fixes a compiler assertion failure in the network directory that resulted from simultaneously dereferencing and incrementing a pointer in a checked scope (see [checkedc-clang/#863](https://github.com/microsoft/checkedc-clang/issues/863) for more details on pointer dereference/increment). The assertion failure was:

`clang/lib/CodeGen/CGExpr.cpp:4654: clang::CodeGen::LValue clang::CodeGen::CodeGenFunction::EmitBinaryOperatorLValue(const clang::BinaryOperator *): Assertion 'E->getOpcode() == BO_Assign && "unexpected binary l-value"' failed.`

In addition, this PR fixes a compile error in the string directory by changing the `itype` of the string parameter in `strnlen` to `_Nt_array_ptr` to match the `itype` declared in the header file.